### PR TITLE
Update security-client dependency version to 1.0.3 in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,8 +44,13 @@
         <dependency>
             <groupId>com.github.VinaAcademy</groupId>
             <artifactId>security-client</artifactId>
-            <version>v1.0.2</version>
+            <version>v1.0.3</version>
         </dependency>
+<!--        <dependency>
+            <groupId>vn.vinaacademy</groupId>
+            <artifactId>security-client</artifactId>
+            <version>1.0.3</version>
+    </dependency>-->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-mail</artifactId>


### PR DESCRIPTION
This pull request updates a dependency version in the `pom.xml` file to ensure the project uses the latest release of the `security-client` library.

Dependency updates:

* Updated the `security-client` dependency from version `v1.0.2` to `v1.0.3` to incorporate recent improvements and fixes.
* Added a commented-out alternative dependency configuration for `security-client` from a different group and version format, likely for future reference or testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security client dependency to the latest patch version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->